### PR TITLE
tree: import manifests, configs, and jobs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,62 @@
+# Setting up CoreOS CI
+
+First, create the Jenkins base infra:
+
+```
+oc new-app --file=manifests/jenkins.yaml
+```
+
+Use the `NAMESPACE` parameter if you're not targeting one
+named `coreos-ci`.
+
+Create the JCasC configmap:
+
+```
+oc create configmap jenkins-casc-cfg --from-file=jenkins/config
+```
+
+Create the GitHub OAuth secret (these creds currently live
+in jlebon's "CoreOS CI" GitHub OAuth App settings, which he
+will soon transfer to the coreos/ org).
+
+```
+oc secret new github-oauth client-id=github-oauth-client-id client-secret=github-oauth-client-secret
+```
+
+Create the GitHub webhook shared secret (XXX: jlebon to put
+it in the shared secrets repo):
+
+```
+oc secret new github-webhook-shared-secret secret=github-webhook-shared-secret
+```
+
+Create the CoreOS Bot (coreosbot) GitHub token (these creds
+are available from bgilbert; XXX: jlebon or bgilbert to put
+it in the shared secrets repo):
+
+```
+oc secret new github-coreosbot-token token=coreosbot-github-token
+```
+
+Now we can set up the Jenkins S2I builds. We use the same
+settings as the FCOS pipeline to ensure that the environment
+is the same (notably, Jenkins and plugin versions):
+
+```
+oc process -l app=coreos-ci -f https://raw.githubusercontent.com/coreos/fedora-coreos-pipeline/master/manifests/jenkins-s2i.yaml | oc create -f -
+```
+
+If working on your own fork/branch, you can use the
+`JENKINS_JOBS_URL` and `JENKINS_JOBS_REF` parameters to
+override the repo in which to look for jobs, and/or
+`JENKINS_S2I_URL` and `JENKINS_S2I_REF` to override the repo
+in which to look for the Jenkins S2I configuration.
+
+Then start a build:
+
+```
+oc start-build jenkins
+```
+
+And that's it! It's already set up so that jobs will be
+created on first boot, etc...

--- a/README.md
+++ b/README.md
@@ -9,44 +9,32 @@ It may end up being merged into
 https://github.com/coreos/fedora-coreos-pipeline in the
 future.
 
-### projectatomic-ci
+CoreOS CI uses the same S2I builder defined in the
+[Fedora CoreOS pipeline](https://github.com/coreos/fedora-coreos-pipeline/tree/master/jenkins/master).
+All build config and plugin changes should happen there.
 
-Upstream CI jobs are currently created manually and running
-in https://jenkins-projectatomic-ci.apps.ci.centos.org/ .
-Only jlebon and cgwalters can create jobs there (the new
-Jenkins will use GitHub OAuth to delegate administration to
-the whole CoreOS team).
+### Enrolling a new repo for upstream CI
 
-To create a new job by copying:
-- Sign in as jlebon or walters
-- `New Item`
-- Name it the same as the repository, e.g. `ignition`
-- Copy from `rpm-ostree`
-- `OK`
-- In the job configuration, clear the description and change
-  the target repo, e.g. `ignition`
-- `Save`
+To enroll a repo, simply open a patch to have it added to
+the list in `seed-github-ci.Jenkinsfile`.
 
-To create a new job without copying:
-- Branch Sources -> GitHub
-    - Credentials -> coreosbot
-    - fill in Owner and Repo
-    - Discover pull requests from forks -> Trust ->
-      Contributors
-    - Add Property -> Pipeline Branch speed/durability
-      override -> Performance-optimized
-- Build Configuration -> Script Path -> .cci.jenkinsfile
-- Scan Multibranch Pipeline Triggers -> Check Periodically
-  -> 1 day
-- Orphaned Item Strategy -> Discard old items (keep checked)
-- `Save`
+### Adding a job
 
-For push notifications:
-- Add a new webhook on the target repo settings:
-    - Payload URL: https://jenkins-projectatomic-ci.apps.ci.centos.org/github-webhook/
-    - Content Type: application/json
-    - Shared Secret: get it from the OpenShift secret
-      `github-webhook-shared-secret` in `coreos-ci` or
-      `projectatomic-ci`
-    - Keep SSL verification enabled
-    - Just select `Pull Requests` & `Pushes`
+While CoreOS CI is today mostly focused on GitHub PR
+testing, it is flexible enough to contain other related
+jobs.
+
+Any Jenkinsfile added in the `jobs/` directory will be
+converted into a pipeline job.
+
+### Repo structure
+
+The `jenkins/config` directory contains
+[Configuration as Code](https://github.com/jenkinsci/configuration-as-code-plugin)
+fragments to configure Jenkins on startup.
+
+The `jobs/` directory contains Jenkinsfiles which are
+converted to pipeline jobs.
+
+The `manifests/` directory contains the OpenShift template
+for creating Jenkins itself.

--- a/jenkins/config/github-coreosbot.yaml
+++ b/jenkins/config/github-coreosbot.yaml
@@ -1,0 +1,10 @@
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+        - usernamePassword:
+            scope: GLOBAL
+            id: github-coreosbot-token
+            username: coreosbot
+            password: ${github-coreosbot-token/token}
+            description: GitHub coreosbot token

--- a/jenkins/config/github-oauth.yaml
+++ b/jenkins/config/github-oauth.yaml
@@ -1,0 +1,26 @@
+jenkins:
+  securityRealm:
+    github:
+      githubWebUri: https://github.com
+      githubApiUri: https://api.github.com
+      clientID: ${github-oauth/client-id}
+      clientSecret: ${github-oauth/client-secret}
+      oauthScopes: read:org,user:email,repo
+  authorizationStrategy:
+    globalMatrix:
+      permissions:
+      # only the fedora-coreos-tools and fedora-coreos-releng teams can fully
+      # administer Jenkins
+      - "Overall/Administer:coreos*fedora-coreos-tools"
+      - "Overall/Administer:coreos*fedora-coreos-releng"
+      # allow anyone in coreos/ostreedev/openshift to cancel and retrigger runs
+      - "Job/Build:coreos"
+      - "Job/Build:ostreedev"
+      - "Job/Build:openshift"
+      - "Job/Cancel:coreos"
+      - "Job/Cancel:ostreedev"
+      - "Job/Cancel:openshift"
+      # anonymous people can only see logs
+      - "Overall/Read:anonymous"
+      - "Job/Read:anonymous"
+      - "View/Read:anonymous"

--- a/jenkins/config/github-webhook.yaml
+++ b/jenkins/config/github-webhook.yaml
@@ -1,0 +1,13 @@
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+        - string:
+            scope: GLOBAL
+            id: github-webhook-shared-secret
+            secret: ${github-webhook-shared-secret/secret}
+            description: GitHub Webhook Shared Secret
+unclassified:
+  gitHubPluginConfig:
+    hookSecretConfig:
+      credentialsId: github-webhook-shared-secret

--- a/jenkins/config/seed.yaml
+++ b/jenkins/config/seed.yaml
@@ -1,0 +1,51 @@
+# This seed job simply defines a new pipeline job for each Jenkinsfile found in
+# the jobs/ directory of the target jenkins jobs repo.
+
+security:
+  globalJobDslSecurityConfiguration:
+    # turn off approval for job DSL; we already approve scripts via PR review
+    useScriptSecurity: false
+jobs:
+  - script: |
+      pipelineJob('seed') {
+        definition {
+          cps {
+            sandbox(true)
+            script('''
+              node {
+                // XXX: hack, should put this in coreos-ci-lib
+                sh("curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-pipeline/master/utils.groovy")
+                def utils = load("utils.groovy")
+
+                def url = utils.get_annotation("jenkins", "jenkins-jobs-url")
+                def ref = utils.get_annotation("jenkins", "jenkins-jobs-ref")
+                utils.shwrap("rm -rf source")
+                utils.shwrap("git clone -b ^${ref} ^${url} source")
+
+                findFiles(glob: "source/jobs/*.Jenkinsfile").each { file ->
+                  def split = file.name.split("\\\\.")
+                  assert split[1] == "Jenkinsfile"
+                  def jobName = split[0]
+                  jobDsl scriptText: """
+                    pipelineJob("^${jobName}") {
+                      definition {
+                        cpsScm {
+                          scm {
+                            git {
+                              remote { url("^${url}") }
+                              branches("^${ref}")
+                              extensions { }
+                            }
+                            scriptPath("jobs/^${file.name}")
+                          }
+                        }
+                      }
+                    }
+                  """
+                }
+              }
+            '''.stripIndent())
+          }
+        }
+      }
+      queue('seed')

--- a/jobs/seed-github-ci.Jenkinsfile
+++ b/jobs/seed-github-ci.Jenkinsfile
@@ -1,0 +1,75 @@
+/* this job defines all the multibranch jobs for upstream CI repos */
+
+repos = [
+    // "coreos/coreos-assembler",
+    // "coreos/fedora-coreos-config",
+    // "coreos/fedora-coreos-pipeline",
+    // "coreos/fedora-coreos-streams",
+    // "coreos/ignition",
+    // "coreos/mantle",
+    // "coreos/rpm-ostree",
+    // "ostreedev/ostree
+]
+
+node { repos.each { repo ->
+    def (owner, name) = repo.split('/')
+    jobDsl scriptText: """
+        folder('github-ci')
+        folder('github-ci/${owner}')
+        multibranchPipelineJob('github-ci/${repo}') {
+            branchSources {
+                github {
+                    // id must be constant so that job updates work correctly
+                    id("fac233be-96f9-4331-851b-6153fdc9af9b")
+                    repoOwner('${owner}')
+                    repository('${name}')
+                    checkoutCredentialsId("github-coreosbot-token")
+                    scanCredentialsId("github-coreosbot-token")
+                }
+            }
+            factory {
+                workflowBranchProjectFactory {
+                    scriptPath('.cci.jenkinsfile')
+                }
+            }
+            orphanedItemStrategy {
+                discardOldItems()
+            }
+            triggers {
+                // manually rescan once a day; this is important so that it
+                // picks up on deleted branches/PRs which can be cleaned up
+                periodic(60 * 24)
+            }
+            // things which don't seem to have a nice DSL :(
+            configure {
+                it / sources / data / 'jenkins.branch.BranchSource' / strategy {
+                    properties(class: 'java.util.Arrays\$ArrayList') {
+                        a(class: 'jenkins.branch.BranchProperty-array') {
+                            'org.jenkinsci.plugins.workflow.multibranch.DurabilityHintBranchProperty' {
+                                // we don't care about durability for these CI
+                                // jobs. we should be able to interrupt and
+                                // restart from scratch whenever
+                                hint('PERFORMANCE_OPTIMIZED')
+                            }
+                        }
+                    }
+                }
+                it / sources / data / 'jenkins.branch.BranchSource' / source << {
+                    traits {
+                        'org.jenkinsci.plugins.github__branch__source.BranchDiscoveryTrait' {
+                            strategyId(1)
+                        }
+                        'org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait' {
+                            strategyId(1)
+                        }
+                        'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
+                            strategyId(1)
+                            // allow testing of PRs from project contributors
+                            trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait\$TrustContributors')
+                        }
+                    }
+                }
+            }
+        }
+    """
+}}

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -1,0 +1,231 @@
+# This is a fork of the `jenkins-ephemeral` OpenShift template because we need
+# to be able to pass in more information to the Jenkins pod, such as env vars,
+# secrets, configmaps, etc...
+
+apiVersion: v1
+kind: Template
+labels:
+  app: coreos-ci
+  template: coreos-ci-jenkins-template
+metadata:
+  annotations:
+    description: |-
+      Jenkins service for CoreOS CI.
+    iconClass: icon-jenkins
+    openshift.io/display-name: CoreOS CI Jenkins
+    openshift.io/documentation-url: https://github.com/coreos/coreos-ci
+    openshift.io/support-url: https://github.com/coreos/coreos-ci
+    openshift.io/provider-display-name: CoreOS CI
+    tags: fcos,jenkins,coreos,ci
+  name: coreos-ci-jenkins
+objects:
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${JENKINS_SERVICE_NAME}
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: OPENSHIFT_ENABLE_OAUTH
+            value: ${ENABLE_OAUTH}
+          - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
+            value: "true"
+          - name: OPENSHIFT_JENKINS_JVM_ARCH
+            value: ${JVM_ARCH}
+          - name: KUBERNETES_MASTER
+            value: https://kubernetes.default:443
+          - name: KUBERNETES_TRUST_CERTIFICATES
+            value: "true"
+          - name: JNLP_SERVICE_NAME
+            value: ${JNLP_SERVICE_NAME}
+          # DELTA: point c-as-c plugin to config map files; see below
+          - name: CASC_JENKINS_CONFIG
+            value: /var/lib/jenkins/configuration-as-code
+          image: ' '
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 420
+            timeoutSeconds: 3
+          name: jenkins
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 3
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/jenkins
+            name: ${JENKINS_SERVICE_NAME}-data
+          # DELTA: mount c-as-c config map
+          - name: ${JENKINS_SERVICE_NAME}-casc-cfg
+            mountPath: /var/lib/jenkins/configuration-as-code
+            readOnly: true
+          # DELTA: mount GitHub OAuth secrets
+          - name: github-oauth
+            mountPath: /var/run/secrets/github-oauth
+            readOnly: true
+          # DELTA: mount GitHub webhook shared secret
+          - name: github-webhook-shared-secret
+            mountPath: /var/run/secrets/github-webhook-shared-secret
+            readOnly: true
+          # DELTA: mount GitHub coreosbot token
+          - name: github-coreosbot-token
+            mountPath: /var/run/secrets/github-coreosbot-token
+            readOnly: true
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        serviceAccountName: ${JENKINS_SERVICE_NAME}
+        volumes:
+        - emptyDir:
+            medium: ""
+          name: ${JENKINS_SERVICE_NAME}-data
+        # DELTA: add a configmap -- see config/jcasc.yaml
+        - name: ${JENKINS_SERVICE_NAME}-casc-cfg
+          configMap:
+            name: jenkins-casc-cfg
+        # DELTA: add the GitHub OAuth creds
+        - name: github-oauth
+          secret:
+            secretName: github-oauth
+        # DELTA: add the GitHub OAuth creds
+        - name: github-webhook-shared-secret
+          secret:
+            secretName: github-webhook-shared-secret
+        # DELTA: add the GitHub coreosbot token
+        - name: github-coreosbot-token
+          secret:
+            secretName: github-coreosbot-token
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - jenkins
+        from:
+          kind: ImageStreamTag
+          name: ${JENKINS_IMAGE_STREAM_TAG}
+          namespace: ${NAMESPACE}
+        lastTriggeredImage: ""
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.jenkins: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${JENKINS_SERVICE_NAME}"}}'
+    name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  groupNames: null
+  kind: RoleBinding
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}_edit
+  roleRef:
+    name: edit
+  subjects:
+  - kind: ServiceAccount
+    name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ${JNLP_SERVICE_NAME}
+  spec:
+    ports:
+    - name: agent
+      nodePort: 0
+      port: 50000
+      protocol: TCP
+      targetPort: 50000
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/dependencies: '[{"name": "${JNLP_SERVICE_NAME}",
+        "namespace": "", "kind": "Service"}]'
+      service.openshift.io/infrastructure: "true"
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    ports:
+    - name: web
+      nodePort: 0
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+parameters:
+- description: The name of the OpenShift Service exposed for the Jenkins container.
+  displayName: Jenkins Service Name
+  name: JENKINS_SERVICE_NAME
+  value: jenkins
+- description: The name of the service used for master/slave communication.
+  displayName: Jenkins JNLP Service Name
+  name: JNLP_SERVICE_NAME
+  value: jenkins-jnlp
+- description: Whether to enable OAuth OpenShift integration. If false, the static
+    account 'admin' will be initialized with the password 'password'.
+  displayName: Enable OAuth in Jenkins
+  name: ENABLE_OAUTH
+  # DELTA: changed from true; we're using GitHub OAuth
+  value: "false"
+- description: Whether Jenkins runs with a 32 bit (i386) or 64 bit (x86_64) JVM.
+  displayName: Jenkins JVM Architecture
+  name: JVM_ARCH
+  value: i386
+- description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  # DELTA: changed from 512Mi
+  name: MEMORY_LIMIT
+  value: 2Gi
+- description: The OpenShift Namespace where the Jenkins ImageStream resides.
+  displayName: Jenkins ImageStream Namespace
+  name: NAMESPACE
+  # DELTA: changed from openshift
+  value: coreos-ci
+- description: Name of the ImageStreamTag to be used for the Jenkins image.
+  displayName: Jenkins ImageStreamTag
+  name: JENKINS_IMAGE_STREAM_TAG
+  # DELTA: changed from jenkins:latest
+  # https://github.com/coreos/fedora-coreos-pipeline/pull/70
+  value: jenkins:2

--- a/manifests/jenkins.yaml.orig
+++ b/manifests/jenkins.yaml.orig
@@ -1,0 +1,209 @@
+# This is the original Jenkins template from which we forked. Will be useful
+# for rebasing.
+#
+# Obtained using:
+#   oc get templates -n openshift -o yaml jenkins-ephemeral > manifests/jenkins.yaml.orig
+#
+# To diff:
+#   git diff --no-index manifests/jenkins.yaml{.orig,}
+
+apiVersion: v1
+kind: Template
+labels:
+  template: jenkins-ephemeral-template
+message: A Jenkins service has been created in your project.  Log into Jenkins with
+  your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
+  contains more information about using this template.
+metadata:
+  annotations:
+    description: |-
+      Jenkins service, without persistent storage.
+
+      WARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.
+    iconClass: icon-jenkins
+    openshift.io/display-name: Jenkins (Ephemeral)
+    tags: instant-app,jenkins
+    template.openshift.io/documentation-url: https://docs.openshift.org/latest/using_images/other_images/jenkins.html
+    template.openshift.io/long-description: This template deploys a Jenkins server
+      capable of managing OpenShift Pipeline builds and supporting OpenShift-based
+      oauth login.  The Jenkins configuration is stored in non-persistent storage,
+      so this configuration should be used for experimental purposes only.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+    template.openshift.io/support-url: https://access.redhat.com
+  creationTimestamp: 2017-06-07T22:44:34Z
+  name: jenkins-ephemeral
+  namespace: openshift
+  resourceVersion: "9280677"
+  selfLink: /oapi/v1/namespaces/openshift/templates/jenkins-ephemeral
+  uid: e101774f-4bd2-11e7-aab3-0cc47a66a374
+objects:
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${JENKINS_SERVICE_NAME}
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: OPENSHIFT_ENABLE_OAUTH
+            value: ${ENABLE_OAUTH}
+          - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
+            value: "true"
+          - name: OPENSHIFT_JENKINS_JVM_ARCH
+            value: ${JVM_ARCH}
+          - name: KUBERNETES_MASTER
+            value: https://kubernetes.default:443
+          - name: KUBERNETES_TRUST_CERTIFICATES
+            value: "true"
+          - name: JNLP_SERVICE_NAME
+            value: ${JNLP_SERVICE_NAME}
+          image: ' '
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 420
+            timeoutSeconds: 3
+          name: jenkins
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 3
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/jenkins
+            name: ${JENKINS_SERVICE_NAME}-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        serviceAccountName: ${JENKINS_SERVICE_NAME}
+        volumes:
+        - emptyDir:
+            medium: ""
+          name: ${JENKINS_SERVICE_NAME}-data
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - jenkins
+        from:
+          kind: ImageStreamTag
+          name: ${JENKINS_IMAGE_STREAM_TAG}
+          namespace: ${NAMESPACE}
+        lastTriggeredImage: ""
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.jenkins: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${JENKINS_SERVICE_NAME}"}}'
+    name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  groupNames: null
+  kind: RoleBinding
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}_edit
+  roleRef:
+    name: edit
+  subjects:
+  - kind: ServiceAccount
+    name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ${JNLP_SERVICE_NAME}
+  spec:
+    ports:
+    - name: agent
+      nodePort: 0
+      port: 50000
+      protocol: TCP
+      targetPort: 50000
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/dependencies: '[{"name": "${JNLP_SERVICE_NAME}",
+        "namespace": "", "kind": "Service"}]'
+      service.openshift.io/infrastructure: "true"
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    ports:
+    - name: web
+      nodePort: 0
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+parameters:
+- description: The name of the OpenShift Service exposed for the Jenkins container.
+  displayName: Jenkins Service Name
+  name: JENKINS_SERVICE_NAME
+  value: jenkins
+- description: The name of the service used for master/slave communication.
+  displayName: Jenkins JNLP Service Name
+  name: JNLP_SERVICE_NAME
+  value: jenkins-jnlp
+- description: Whether to enable OAuth OpenShift integration. If false, the static
+    account 'admin' will be initialized with the password 'password'.
+  displayName: Enable OAuth in Jenkins
+  name: ENABLE_OAUTH
+  value: "true"
+- description: Whether Jenkins runs with a 32 bit (i386) or 64 bit (x86_64) JVM.
+  displayName: Jenkins JVM Architecture
+  name: JVM_ARCH
+  value: i386
+- description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  value: 512Mi
+- description: The OpenShift Namespace where the Jenkins ImageStream resides.
+  displayName: Jenkins ImageStream Namespace
+  name: NAMESPACE
+  value: openshift
+- description: Name of the ImageStreamTag to be used for the Jenkins image.
+  displayName: Jenkins ImageStreamTag
+  name: JENKINS_IMAGE_STREAM_TAG
+  value: jenkins:latest


### PR DESCRIPTION
This commit includes all the juicy bits needed to set up a Jenkins
instance in which to run our upstream CI. Lots going on here, but some
highlights:
- the configs are fully declarative; there's nothing more to set up once
  Jenkins is up (well, almost... working on that)
- we use the same Jenkins build config as the FCOS pipeline to match its
  environment
- we set up GitHub OAuth for authentication
- the job creation system is kept flexible enough that it's not *just*
  for running GitHub PR tests, any arbitrary job can be added; one
  simply needs to add the Jenkinsfile to `jobs/` (in fact, I'd like to
  experiment with the same setup for the FCOS pipeline itself)

Anyway, there's more tweaks needed to get this where we want, but I
think it's in a good enough state to get it in.